### PR TITLE
Debug cors patch request error

### DIFF
--- a/apps/backend/middleware/securityHeaders.ts
+++ b/apps/backend/middleware/securityHeaders.ts
@@ -16,15 +16,6 @@ export const securityHeaders = () => {
     // HSTS (uncomment in production)
     // c.header("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
 
-    // CORS headers (if not using Hono's cors middleware)
-    c.header("Access-Control-Allow-Origin", process.env.ALLOWED_ORIGINS || "*");
-    c.header(
-      "Access-Control-Allow-Methods",
-      "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-    );
-    c.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
-    c.header("Access-Control-Max-Age", "86400");
-
     await next();
   };
 };

--- a/apps/backend/utils/middlewareSetup.ts
+++ b/apps/backend/utils/middlewareSetup.ts
@@ -16,7 +16,25 @@ export function setupMiddlewares(
 ): void {
   // Apply global middlewares
   app.use("*", logger());
-  app.use("*", cors());
+  app.use(
+    "*",
+    cors({
+      origin:
+        process.env.ALLOWED_ORIGINS
+          ? process.env.ALLOWED_ORIGINS.split(",")
+          : "*",
+      allowMethods: [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "OPTIONS",
+      ],
+      allowHeaders: ["Content-Type", "Authorization"],
+      maxAge: 86400,
+    }),
+  );
   app.use("*", securityHeaders());
   app.use(
     "*",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
       - "traefik.http.services.backend.loadbalancer.server.port=3000"
       - "traefik.http.routers.backend.tls=false" # Disable SSL for localhost
       - "traefik.http.routers.backend.middlewares=backend-headers"
-      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
+      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,PATCH,OPTIONS"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowheaders=*"
 

--- a/docker-compose.ngrok.yml
+++ b/docker-compose.ngrok.yml
@@ -10,7 +10,7 @@ services:
       - "traefik.http.services.backend.loadbalancer.server.port=3000"
       - "traefik.http.routers.backend.tls=false" # Disable SSL for ngrok
       - "traefik.http.routers.backend.middlewares=backend-headers"
-      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
+      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,PATCH,OPTIONS"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowheaders=*"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,7 +171,7 @@ services:
       - "traefik.http.services.backend.loadbalancer.server.port=3000"
       - "traefik.http.routers.backend.tls.certresolver=letsencrypt"
       - "traefik.http.routers.backend.middlewares=backend-headers"
-      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,OPTIONS"
+      - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowmethods=GET,POST,PUT,DELETE,PATCH,OPTIONS"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolalloworiginlist=*"
       - "traefik.http.middlewares.backend-headers.headers.accesscontrolallowheaders=*"
 


### PR DESCRIPTION
Enable PATCH method for CORS by configuring Hono middleware and updating Traefik labels to resolve `PATCH` method not allowed error.

The original issue was a CORS error where `PATCH` requests were blocked. This was due to Traefik's proxy injecting CORS headers that did not include `PATCH`, overriding the application's own CORS settings. The fix involves both explicitly allowing `PATCH` in the Hono CORS middleware and updating Traefik's `accesscontrolallowmethods` labels in the Docker Compose files. Redundant CORS headers in `securityHeaders.ts` were also removed to prevent conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dbe1775-4562-4675-b246-833d4e62e511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dbe1775-4562-4675-b246-833d4e62e511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

