### PR TITLE
feat: InterestAlignmentPolicy pure scorer + selection helper

### DIFF
--- a/apps/backend/services/prescription/InterestAlignmentPolicy.test.ts
+++ b/apps/backend/services/prescription/InterestAlignmentPolicy.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import {
+  scoreInterestAlignment,
+  selectInterestAligned,
+  type InterestSignals,
+} from "./InterestAlignmentPolicy";
+import type { ScoutCandidate } from "./PrescriptionStrategy";
+
+function candidate(overrides: Partial<ScoutCandidate> = {}): ScoutCandidate {
+  return {
+    venueName: "Test Venue",
+    venueAddress: "123 Test St",
+    venueCategory: "Other",
+    latitude: 0,
+    longitude: 0,
+    source: "search_places",
+    ...overrides,
+  };
+}
+
+function signals(overrides: Partial<InterestSignals> = {}): InterestSignals {
+  return {
+    activities: [],
+    goalTags: [],
+    primaryGoal: null,
+    ...overrides,
+  };
+}
+
+describe("scoreInterestAlignment — category overlap", () => {
+  test("category that names a stated activity outranks an unrelated category", () => {
+    const aligned = scoreInterestAlignment(
+      candidate({ venueCategory: "Climbing Gym" }),
+      signals({ activities: ["climbing"] }),
+    );
+    const unrelated = scoreInterestAlignment(
+      candidate({ venueCategory: "Coffee Shop" }),
+      signals({ activities: ["climbing"] }),
+    );
+    expect(aligned).toBeGreaterThan(unrelated);
+  });
+
+  test("zero stated interests yields zero — nothing to align against", () => {
+    const score = scoreInterestAlignment(
+      candidate({ venueCategory: "Climbing Gym" }),
+      signals({ activities: [] }),
+    );
+    expect(score).toBe(0);
+  });
+
+  test("category with no overlap yields zero so the hard-filter can gate on it", () => {
+    const score = scoreInterestAlignment(
+      candidate({ venueCategory: "Coffee Shop" }),
+      signals({ activities: ["climbing", "yoga"] }),
+    );
+    expect(score).toBe(0);
+  });
+});
+
+describe("scoreInterestAlignment — Google type signals", () => {
+  test("googleTypes can carry the interest signal when category is generic", () => {
+    const score = scoreInterestAlignment(
+      candidate({
+        venueCategory: "Park",
+        googleTypes: ["park", "climbing_gym"],
+      }),
+      signals({ activities: ["climbing"] }),
+    );
+    expect(score).toBeGreaterThan(0);
+  });
+
+  test("googlePrimaryType participates the same way", () => {
+    const score = scoreInterestAlignment(
+      candidate({
+        venueCategory: "Other",
+        googlePrimaryType: "yoga_studio",
+      }),
+      signals({ activities: ["yoga"] }),
+    );
+    expect(score).toBeGreaterThan(0);
+  });
+});
+
+describe("scoreInterestAlignment — comfort-profile signals", () => {
+  test("primaryGoal contributes when activities are silent", () => {
+    const score = scoreInterestAlignment(
+      candidate({ venueCategory: "Pottery Studio" }),
+      signals({
+        activities: [],
+        primaryGoal: "find a pottery class",
+      }),
+    );
+    expect(score).toBeGreaterThan(0);
+  });
+
+  test("goalTags lift hands-on venues for discover_hobby goal", () => {
+    const score = scoreInterestAlignment(
+      candidate({
+        venueCategory: "Workshop / Class Venue",
+        googleTypes: ["workshop"],
+      }),
+      signals({ goalTags: ["discover_hobby"] }),
+    );
+    expect(score).toBeGreaterThan(0);
+  });
+
+  test("goalTags do not lift venues unrelated to the goal vocabulary", () => {
+    const score = scoreInterestAlignment(
+      candidate({ venueCategory: "Bar" }),
+      signals({ goalTags: ["discover_hobby"] }),
+    );
+    expect(score).toBe(0);
+  });
+
+  test("an activity-aligned candidate still outranks a goal-tag-only match", () => {
+    const direct = scoreInterestAlignment(
+      candidate({ venueCategory: "Climbing Gym" }),
+      signals({
+        activities: ["climbing"],
+        goalTags: ["discover_hobby"],
+      }),
+    );
+    const indirect = scoreInterestAlignment(
+      candidate({ venueCategory: "Workshop / Class Venue" }),
+      signals({
+        activities: ["climbing"],
+        goalTags: ["discover_hobby"],
+      }),
+    );
+    expect(direct).toBeGreaterThan(indirect);
+  });
+});
+
+describe("selectInterestAligned — hard-floor enforcement", () => {
+  test("ok when at least minAligned candidates have non-zero score", () => {
+    const result = selectInterestAligned(
+      [
+        { candidate: candidate({ venueName: "A" }), score: 1 },
+        { candidate: candidate({ venueName: "B" }), score: 0.6 },
+        { candidate: candidate({ venueName: "C" }), score: 0.4 },
+        { candidate: candidate({ venueName: "D" }), score: 0 },
+        { candidate: candidate({ venueName: "E" }), score: 0 },
+      ],
+      { count: 5, minAligned: 3 },
+    );
+    expect(result.status).toBe("ok");
+  });
+
+  test("insufficient_aligned when fewer than minAligned non-zero — signals envelope expansion", () => {
+    const result = selectInterestAligned(
+      [
+        { candidate: candidate({ venueName: "A" }), score: 1 },
+        { candidate: candidate({ venueName: "B" }), score: 0.6 },
+        { candidate: candidate({ venueName: "C" }), score: 0 },
+        { candidate: candidate({ venueName: "D" }), score: 0 },
+        { candidate: candidate({ venueName: "E" }), score: 0 },
+      ],
+      { count: 5, minAligned: 3 },
+    );
+    expect(result.status).toBe("insufficient_aligned");
+    if (result.status === "insufficient_aligned") {
+      expect(result.alignedCount).toBe(2);
+    }
+  });
+
+  test("selected slate front-loads aligned candidates by score, then fills with non-aligned", () => {
+    const result = selectInterestAligned(
+      [
+        { candidate: candidate({ venueName: "weak-aligned" }), score: 0.4 },
+        { candidate: candidate({ venueName: "filler-1" }), score: 0 },
+        { candidate: candidate({ venueName: "strong-aligned" }), score: 1 },
+        { candidate: candidate({ venueName: "mid-aligned" }), score: 0.6 },
+        { candidate: candidate({ venueName: "filler-2" }), score: 0 },
+        { candidate: candidate({ venueName: "filler-3" }), score: 0 },
+      ],
+      { count: 5, minAligned: 3 },
+    );
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      const names = result.selected.map((s) => s.candidate.venueName);
+      expect(names.slice(0, 3)).toEqual([
+        "strong-aligned",
+        "mid-aligned",
+        "weak-aligned",
+      ]);
+      expect(result.selected).toHaveLength(5);
+      const alignedInSlate = result.selected.filter((s) => s.score > 0).length;
+      expect(alignedInSlate).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test("preserves caller's tie-breaking order among non-aligned fillers", () => {
+    const result = selectInterestAligned(
+      [
+        { candidate: candidate({ venueName: "aligned-1" }), score: 1 },
+        { candidate: candidate({ venueName: "aligned-2" }), score: 1 },
+        { candidate: candidate({ venueName: "aligned-3" }), score: 1 },
+        { candidate: candidate({ venueName: "filler-A" }), score: 0 },
+        { candidate: candidate({ venueName: "filler-B" }), score: 0 },
+      ],
+      { count: 5, minAligned: 3 },
+    );
+    if (result.status === "ok") {
+      const fillerOrder = result.selected
+        .filter((s) => s.score === 0)
+        .map((s) => s.candidate.venueName);
+      expect(fillerOrder).toEqual(["filler-A", "filler-B"]);
+    }
+  });
+});

--- a/apps/backend/services/prescription/InterestAlignmentPolicy.ts
+++ b/apps/backend/services/prescription/InterestAlignmentPolicy.ts
@@ -1,0 +1,122 @@
+import type { ScoutCandidate } from "./PrescriptionStrategy";
+
+export interface InterestSignals {
+  activities: string[];
+  goalTags: string[];
+  primaryGoal: string | null;
+}
+
+const ACTIVITY_WEIGHT = 1.0;
+const PRIMARY_GOAL_WEIGHT = 0.6;
+const GOAL_TAG_WEIGHT = 0.4;
+
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "to",
+  "for",
+  "of",
+  "in",
+  "on",
+  "at",
+  "with",
+  "find",
+  "get",
+  "go",
+  "make",
+  "do",
+  "i",
+  "my",
+  "me",
+  "want",
+  "need",
+  "class",
+  "place",
+  "spot",
+]);
+
+const GOAL_TAG_KEYWORDS: Record<string, string[]> = {
+  discover_hobby: ["workshop", "class", "studio", "lesson", "maker", "open"],
+  dating: ["bar", "cafe", "social", "dance", "lounge"],
+  community: ["community", "meetup", "club", "volunteer", "neighborhood"],
+};
+
+function candidateHaystack(candidate: ScoutCandidate): string {
+  return [
+    candidate.venueCategory,
+    candidate.googlePrimaryType ?? "",
+    candidate.googlePrimaryTypeDisplayName ?? "",
+    ...(candidate.googleTypes ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((tok) => tok.length > 2 && !STOP_WORDS.has(tok));
+}
+
+function anyTokenMatches(haystack: string, tokens: string[]): boolean {
+  return tokens.some((tok) => haystack.includes(tok));
+}
+
+export interface ScoredCandidate {
+  candidate: ScoutCandidate;
+  score: number;
+}
+
+export type SelectInterestAlignedResult =
+  | { status: "ok"; selected: ScoredCandidate[] }
+  | { status: "insufficient_aligned"; alignedCount: number };
+
+export function selectInterestAligned(
+  scored: ScoredCandidate[],
+  opts: { count: number; minAligned: number },
+): SelectInterestAlignedResult {
+  const aligned = scored
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score);
+  if (aligned.length < opts.minAligned) {
+    return { status: "insufficient_aligned", alignedCount: aligned.length };
+  }
+  const fillers = scored.filter((s) => s.score === 0);
+  return {
+    status: "ok",
+    selected: [...aligned, ...fillers].slice(0, opts.count),
+  };
+}
+
+export function scoreInterestAlignment(
+  candidate: ScoutCandidate,
+  signals: InterestSignals,
+): number {
+  const haystack = candidateHaystack(candidate);
+  let score = 0;
+
+  for (const activity of signals.activities) {
+    if (anyTokenMatches(haystack, tokenize(activity))) {
+      score = Math.max(score, ACTIVITY_WEIGHT);
+    }
+  }
+
+  if (signals.primaryGoal) {
+    if (anyTokenMatches(haystack, tokenize(signals.primaryGoal))) {
+      score = Math.max(score, PRIMARY_GOAL_WEIGHT);
+    }
+  }
+
+  for (const tag of signals.goalTags) {
+    const keywords = GOAL_TAG_KEYWORDS[tag];
+    if (keywords && anyTokenMatches(haystack, keywords)) {
+      score = Math.max(score, GOAL_TAG_WEIGHT);
+    }
+  }
+
+  return score;
+}


### PR DESCRIPTION
## Summary

Closes the pure-policy half of #120. New module `apps/backend/services/prescription/InterestAlignmentPolicy.ts` with two pure functions:

- `scoreInterestAlignment(candidate, signals)` → `0..1` (0 = no overlap, so the hard-filter binary gate is trivial)
- `selectInterestAligned(scored, {count, minAligned})` → `{status: "ok", selected}` with aligned candidates front-loaded by score, or `{status: "insufficient_aligned", alignedCount}` so the caller can expand the search envelope before falling back to a generic candidate

`InterestSignals` combines `onboardingProfile.activities` (weight 1.0) with comfort-profile `primaryGoal` (0.6) and a small `goalTags` keyword map (0.4).

13 unit tests in the same file, mirroring the prior-art `*Policy.test.ts` shape (`DistancePolicy`, `RecalibrationPolicy`, `OpportunityZonePolicy`).

## Acceptance criteria status (from #120)

- [x] Pure function with no I/O, unit-testable in isolation from the multi-agent stack
- [x] Unit tests cover score order, hard-filter behavior, and the no-aligned-candidate fallback path
- [ ] Candidate selection enforces ≥3 of 5 selected for the first 5 reps — **deferred to follow-up issue (wiring)**
- [ ] Scout expands envelope before generic fallback — **deferred to follow-up issue (wiring)**
- [ ] Fresh-Hermit simulation walkthrough — **deferred to follow-up issue (wiring)**

The wiring into `MultiAgentStrategy` / `VenueScoutAgent` is the larger and riskier half (touches LLM-call paths without unit-test coverage). Splitting it out lets this small, well-tested foundation land first; a follow-up PRD/issue will plan the integration.

## Test plan

- [x] `bun test services/prescription/InterestAlignmentPolicy.test.ts` — 13 pass
- [x] Full backend suite — only pre-existing failures unrelated to this change (fake-DataSource issues that test-harness PRD #125 will fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)