### PR TITLE
feat: InterestAlignmentSelectionGate wired into scout loop (#131)

### DIFF
--- a/apps/backend/services/TraceCollector.ts
+++ b/apps/backend/services/TraceCollector.ts
@@ -33,6 +33,7 @@ export type TraceStage =
   | "scout.submit_candidates"
   // Validator + ranker
   | "quality_match"
+  | "interest_alignment.gate"
   | "validator.attempt"
   | "candidate_ranker"
   // Verification (live web research on winner)

--- a/apps/backend/services/prescription/InterestAlignmentSelectionGate.test.ts
+++ b/apps/backend/services/prescription/InterestAlignmentSelectionGate.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyInterestAlignmentGate,
+  buildInterestSignals,
+} from "./InterestAlignmentSelectionGate";
+import type { InterestSignals } from "./InterestAlignmentPolicy";
+import type { ScoutCandidate } from "./PrescriptionStrategy";
+import type { PrescriptionPromptContext } from "../prompts/PrescriptionPromptRegistry";
+
+function userContext(
+  overrides: Partial<PrescriptionPromptContext["user"]> = {},
+): PrescriptionPromptContext["user"] {
+  return {
+    comfortProfile: null,
+    onboardingProfile: null,
+    pacePreference: null,
+    reachMode: null,
+    fearLadder: null,
+    expectancyCalibration: null,
+    socialSituation: null,
+    ...overrides,
+  };
+}
+
+function candidate(overrides: Partial<ScoutCandidate> = {}): ScoutCandidate {
+  return {
+    venueName: "Test Venue",
+    venueAddress: "123 Test St",
+    venueCategory: "Other",
+    latitude: 0,
+    longitude: 0,
+    source: "search_places",
+    ...overrides,
+  };
+}
+
+function signals(overrides: Partial<InterestSignals> = {}): InterestSignals {
+  return {
+    activities: [],
+    goalTags: [],
+    primaryGoal: null,
+    ...overrides,
+  };
+}
+
+describe("applyInterestAlignmentGate — first-5-reps gate", () => {
+  test("passes through once the user is past their first 5 prescriptions", () => {
+    const decision = applyInterestAlignmentGate({
+      candidates: [candidate({ venueCategory: "Climbing Gym" })],
+      signals: signals({ activities: ["climbing"] }),
+      completedQuestCount: 5,
+    });
+    expect(decision.kind).toBe("passthrough");
+    if (decision.kind === "passthrough") {
+      expect(decision.reason).toBe("past_first_five");
+    }
+  });
+});
+
+describe("applyInterestAlignmentGate — slate construction", () => {
+  test("returns a use_slate decision front-loaded by alignment when the floor is met", () => {
+    // Use distinct signal types so ordering is unambiguous:
+    //   activity → 1.0, primaryGoal → 0.6, goalTag → 0.4.
+    const decision = applyInterestAlignmentGate({
+      candidates: [
+        candidate({ venueName: "filler-1", venueCategory: "Coffee Shop" }),
+        candidate({
+          venueName: "weak-aligned",
+          venueCategory: "Workshop / Class Venue",
+        }),
+        candidate({ venueName: "filler-2", venueCategory: "Coffee Shop" }),
+        candidate({ venueName: "strong-aligned", venueCategory: "Climbing Gym" }),
+        candidate({ venueName: "mid-aligned", venueCategory: "Pottery Studio" }),
+      ],
+      signals: signals({
+        activities: ["climbing"],
+        primaryGoal: "find a pottery class",
+        goalTags: ["discover_hobby"],
+      }),
+      completedQuestCount: 0,
+    });
+    expect(decision.kind).toBe("use_slate");
+    if (decision.kind === "use_slate") {
+      const names = decision.slate.map((c) => c.venueName);
+      expect(names.slice(0, 3)).toEqual([
+        "strong-aligned",
+        "mid-aligned",
+        "weak-aligned",
+      ]);
+      expect(decision.slate).toHaveLength(5);
+      expect(decision.alignedCount).toBe(3);
+    }
+  });
+
+  test("passes through when fewer than 3 aligned candidates exist — fallback path runs unchanged", () => {
+    // Two aligned, three filler — under the 3-of-5 floor.
+    const decision = applyInterestAlignmentGate({
+      candidates: [
+        candidate({ venueName: "aligned-1", venueCategory: "Climbing Gym" }),
+        candidate({ venueName: "aligned-2", venueCategory: "Climbing Gym" }),
+        candidate({ venueName: "filler-1", venueCategory: "Coffee Shop" }),
+        candidate({ venueName: "filler-2", venueCategory: "Coffee Shop" }),
+        candidate({ venueName: "filler-3", venueCategory: "Coffee Shop" }),
+      ],
+      signals: signals({ activities: ["climbing"] }),
+      completedQuestCount: 1,
+    });
+    expect(decision.kind).toBe("passthrough");
+    if (decision.kind === "passthrough") {
+      expect(decision.reason).toBe("insufficient_aligned");
+    }
+  });
+});
+
+describe("buildInterestSignals — pulls from the three onboarding sources", () => {
+  test("populates activities, primaryGoal, and goalTags from a fully-filled user", () => {
+    const built = buildInterestSignals(
+      userContext({
+        onboardingProfile: { activities: ["climbing", "yoga"] },
+        comfortProfile: {
+          primaryGoal: "find a pottery class",
+          goalTags: ["discover_hobby", "community"],
+        },
+      }),
+    );
+    expect(built.activities).toEqual(["climbing", "yoga"]);
+    expect(built.primaryGoal).toBe("find a pottery class");
+    expect(built.goalTags).toEqual(["discover_hobby", "community"]);
+  });
+
+  test("tolerates a sparse user — empty arrays and null primaryGoal — so the gate degrades to passthrough cleanly", () => {
+    const built = buildInterestSignals(userContext());
+    expect(built.activities).toEqual([]);
+    expect(built.goalTags).toEqual([]);
+    expect(built.primaryGoal).toBeNull();
+  });
+});

--- a/apps/backend/services/prescription/InterestAlignmentSelectionGate.ts
+++ b/apps/backend/services/prescription/InterestAlignmentSelectionGate.ts
@@ -1,0 +1,56 @@
+import type { ScoutCandidate } from "./PrescriptionStrategy";
+import {
+  scoreInterestAlignment,
+  selectInterestAligned,
+  type InterestSignals,
+} from "./InterestAlignmentPolicy";
+import type { PrescriptionPromptContext } from "../prompts/PrescriptionPromptRegistry";
+
+const FIRST_REPS_GATE = 5;
+const SLATE_COUNT = 5;
+const MIN_ALIGNED = 3;
+
+export interface InterestAlignmentGateInput {
+  candidates: ScoutCandidate[];
+  signals: InterestSignals;
+  completedQuestCount: number;
+}
+
+export type InterestAlignmentGateDecision =
+  | { kind: "passthrough"; reason: "past_first_five" | "insufficient_aligned" }
+  | { kind: "use_slate"; slate: ScoutCandidate[]; alignedCount: number };
+
+export function applyInterestAlignmentGate(
+  input: InterestAlignmentGateInput,
+): InterestAlignmentGateDecision {
+  if (input.completedQuestCount >= FIRST_REPS_GATE) {
+    return { kind: "passthrough", reason: "past_first_five" };
+  }
+
+  const scored = input.candidates.map((candidate) => ({
+    candidate,
+    score: scoreInterestAlignment(candidate, input.signals),
+  }));
+  const result = selectInterestAligned(scored, {
+    count: SLATE_COUNT,
+    minAligned: MIN_ALIGNED,
+  });
+  if (result.status === "insufficient_aligned") {
+    return { kind: "passthrough", reason: "insufficient_aligned" };
+  }
+  return {
+    kind: "use_slate",
+    slate: result.selected.map((s) => s.candidate),
+    alignedCount: result.selected.filter((s) => s.score > 0).length,
+  };
+}
+
+export function buildInterestSignals(
+  user: PrescriptionPromptContext["user"],
+): InterestSignals {
+  return {
+    activities: user.onboardingProfile?.activities ?? [],
+    goalTags: user.comfortProfile?.goalTags ?? [],
+    primaryGoal: user.comfortProfile?.primaryGoal ?? null,
+  };
+}

--- a/apps/backend/services/prescription/MultiAgentStrategy.ts
+++ b/apps/backend/services/prescription/MultiAgentStrategy.ts
@@ -36,6 +36,10 @@ import { applyGoalMilestonePolicy } from "./GoalMilestonePolicy";
 import { applyContainerOpportunityPolicy } from "./ContainerOpportunityPolicy";
 import { classifyJourneyCategoryFamily } from "./JourneyDiversityContext";
 import { applyOpportunityZonePolicy } from "./OpportunityZonePolicy";
+import {
+  applyInterestAlignmentGate,
+  buildInterestSignals,
+} from "./InterestAlignmentSelectionGate";
 import { buildSearchEnvelope } from "./SearchEnvelope";
 import { VenueScoutAgent } from "./VenueScoutAgent";
 import { QuestWriterAgent } from "./QuestWriterAgent";
@@ -353,6 +357,8 @@ export class MultiAgentStrategy {
     let qualityRetryHint: string | null = null;
     const maxRetries = 2;
     const selectionAttempts: VenueSelectionAttemptTrace[] = [];
+    const interestSignals = buildInterestSignals(promptContext.user);
+    const completedQuestCount = promptContext.completedQuestCount ?? 0;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (onProgress)
@@ -483,6 +489,44 @@ export class MultiAgentStrategy {
             `[multi-agent] QualityMatch: dropped ${droppedNames.length} candidate(s) for hard-avoid hits: ${droppedNames.join(", ")}`,
           );
         }
+      }
+
+      // Interest-alignment gate — enforces a hard interest floor for the
+      // user's first 5 prescriptions. On `use_slate`, replace the candidate
+      // pool with the front-loaded slate so the validator sees aligned
+      // venues first. On `passthrough` (past first-5, or floor unmet in
+      // this slice), the existing fallback path runs unchanged.
+      const gateInputCandidateCount = scoutResult.candidates.length;
+      const gateDecision = applyInterestAlignmentGate({
+        candidates: scoutResult.candidates,
+        signals: interestSignals,
+        completedQuestCount,
+      });
+      if (gateDecision.kind === "use_slate") {
+        scoutResult.candidates = gateDecision.slate;
+        console.log(
+          `[multi-agent] InterestAlignmentGate: use_slate (${gateDecision.alignedCount} aligned of ${gateDecision.slate.length})`,
+        );
+      }
+      if (trace) {
+        await trace.emit("interest_alignment.gate", {
+          input: {
+            signals: interestSignals,
+            candidateCount: gateInputCandidateCount,
+            completedQuestCount,
+          },
+          output:
+            gateDecision.kind === "use_slate"
+              ? {
+                  decision: "use_slate",
+                  alignedCount: gateDecision.alignedCount,
+                  slateSize: gateDecision.slate.length,
+                }
+              : {
+                  decision: "passthrough",
+                  reason: gateDecision.reason,
+                },
+        });
       }
 
       const validation = validateCandidates({


### PR DESCRIPTION
## Summary

- Adds pure `InterestAlignmentSelectionGate` (sibling to existing `*Policy.ts` modules): wraps the already-shipped `selectInterestAligned` for the scout-loop context. Returns `passthrough` (past first 5, or floor unmet) or `use_slate` (front-loaded slate when ≥3 of 5 candidates align). `expand_envelope` is intentionally deferred — when the floor can't be met this slice falls through to the existing fallback path unchanged.
- Wires the gate into `MultiAgentStrategy` after the quality-match filter and before the validator. On `use_slate`, replaces `scoutResult.candidates` with the gate's slate so the validator sees aligned venues first.
- Builds `InterestSignals` from `promptContext.user` (`onboardingProfile.activities`, `comfortProfile.goalTags`, `comfortProfile.primaryGoal`).
- Emits a single `interest_alignment.gate` trace event per scout-loop attempt with the input fingerprint (signals, candidate count, completedQuestCount) and the decision.

Closes #131.

## Test plan

- [x] `bun test services/prescription/InterestAlignmentSelectionGate.test.ts` — 5 new tests pass (TDD'd as tracer bullets, one test → one impl):
  - passthrough on `completedQuestCount >= 5`
  - `use_slate` ordering (activity > primaryGoal > goalTag) with front-loaded slate
  - passthrough when fewer than 3 aligned (slice fallback)
  - `buildInterestSignals` populates from a fully-filled user
  - `buildInterestSignals` tolerates null sub-profiles
- [x] `bun test services/prescription/` — no new failures introduced; the 9 pre-existing failures (DatingProgressionPolicy, buildSearchEnvelope) are unrelated and present on master.
- [x] `tsc --noEmit` — no new type errors; `interest_alignment.gate` added to `TraceStage`. Pre-existing TS errors in OpportunityZonePolicy/ReachRecommendation tests are unrelated.
- [ ] Manual: fresh-Hermit simulation rep 1 prescribes a venue whose category/Google types overlap a stated interest (acceptance test from #120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)